### PR TITLE
Restore ifeq functionality in Makefiles on 10.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ dev_::
 	@echo "[DEV_ARCH] to one of the following:"
 	@echo "  linux -- x86 running Linux with correct libs installed"
 	@echo "  osx -- Mac OSX 10.6+ with xcode"
+	@echo "  solaris9 -- Solaris 9 with correct libs instatlled"
 	@echo " "
 	@echo "  clean -- Clean all files"
 
@@ -23,6 +24,11 @@ osx:
 	cd libwww && $(MAKE) DEV_ARCH=osx
 	cd libhtmlw && $(MAKE) DEV_ARCH=osx
 	cd src && $(MAKE) DEV_ARCH=osx
+
+solaris9:
+	cd libwww && $(MAKE) DEV_ARCH=solaris9
+	cd libhtmlw && $(MAKE) DEV_ARCH=solaris9
+	cd src && $(MAKE) DEV_ARCH=solaris9
 
 clean:
 	cd libhtmlw; $(MAKE) clean

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ I am *not* an expert in Mac OS/X application distribution so I don't have
 any kind of one-click installer simply because I don't have the skills to 
 make such an installer.
 
+<u>Solaris 9 (32-bit)</u>
+The following packages need to be installed:
+
+* SUNWxwice (X Window System Inter-Client Exchange (ICE) Components)
+* SUNWxwplt (X Window System platform software)
+* SUNWxwrtl (X Window System & Graphics Runtime Library Links in /usr/lib)
+
 Compiling the Code
 ==================
 
@@ -40,6 +47,8 @@ You can look at the NCSA README but here are the quick instructions.
 	make linux (Build for Linux)
 
 	make osx (Build for osx)
+
+	make solaris9 (Build for Solaris 9)
 
 From the src directory start xmosaic:
 

--- a/libhtmlw/Makefile
+++ b/libhtmlw/Makefile
@@ -1,8 +1,10 @@
 # ----------------------------------------------------------------------------
 # For normal machines with normal compilers:
-ifeq ($(DEV_ARCH), "linux")
+ifeq ($(DEV_ARCH), linux)
 CC = cc
-else
+endif
+
+ifeq ($(DEV_ARCH), osx)
 CC = cc -mmacosx-version-min=10.5 -arch i386
 endif
 

--- a/libhtmlw/Makefile
+++ b/libhtmlw/Makefile
@@ -8,8 +8,13 @@ ifeq ($(DEV_ARCH), osx)
 CC = cc -mmacosx-version-min=10.5 -arch i386
 endif
 
+ifeq ($(DEV_ARCH), solaris9)
+CC = gcc
+endif
+
 # For Sun's and other non-at-least-pseudo-ANSI-C platforms:
 # CC = gcc
+
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
@@ -23,9 +28,14 @@ endif
 # For SCO:
 # OTHERFLAGS = -DMOTIF1_2
 # For NeXT:
-OTHERFLAGS = -DNEXT -I/usr/include/X11 -I /opt/X11/include/
+# OTHERFLAGS = -DNEXT -I/usr/include/X11 -I /opt/X11/include/
 # For everyone else:
-# OTHERFLAGS = 
+OTHERFLAGS = 
+
+ifeq ($(DEV_ARCH), osx)
+OTHERFLAGS = -DNEXT -I/usr/include/X11 -I /opt/X11/include/
+endif
+
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------

--- a/libwww/HTTCP.c
+++ b/libwww/HTTCP.c
@@ -60,6 +60,11 @@ extern int errno;
 #endif  /* vms */
 #endif	/* VM */
 
+#ifdef SOLARIS9_BROKEN
+extern int sys_nerr;
+extern char *sys_errlist[];
+#endif
+
 #endif	/* PCNFS */
 
 /*	Report Internet Error

--- a/libwww/Makefile
+++ b/libwww/Makefile
@@ -1,8 +1,10 @@
 # ----------------------------------------------------------------------------
 # For normal machines with normal compilers:
-ifeq ($(DEV_ARCH), "linux")
+ifeq ($(DEV_ARCH), linux)
 CC = cc
-else
+endif
+
+ifeq ($(DEV_ARCH), osx)
 CC = cc -g -DNEXT -mmacosx-version-min=10.5 -arch i386
 endif
 
@@ -20,6 +22,7 @@ endif
 # For DEC Alpha OSF/1:
 # CFLAGS = -g -DUSE_DIRENT -DUSE_FILENO
 # For NeXT:
+# CFLAGS = -g -DNEXT
 # For Dell SVR4:
 # CFLAGS = -g -DSVR4
 # For Harris Nighthawk:

--- a/libwww/Makefile
+++ b/libwww/Makefile
@@ -8,6 +8,10 @@ ifeq ($(DEV_ARCH), osx)
 CC = cc -g -DNEXT -mmacosx-version-min=10.5 -arch i386
 endif
 
+ifeq ($(DEV_ARCH), solaris9)
+CC = gcc -m32 -DUSE_DIRENT -DSOLARIS9_BROKEN
+endif
+
 # For Sun's and other non-at-least-pseudo-ANSI-C platforms:
 # CC = gcc
 # ----------------------------------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,6 +23,10 @@ ifeq ($(DEV_ARCH), osx)
  CC = cc -DNEXT -I/usr/include/X11 -I/opt/X11/include -I/usr/OpenMotif/include -mmacosx-version-min=10.5 -arch i386 -Dosx
 endif
 
+ifeq ($(DEV_ARCH), solaris9)
+ CC = gcc
+endif
+
 # For Dell SVR4:
 # CC = cc -DSVR4
 # ----------------------------------------------------------------------------
@@ -48,6 +52,10 @@ ifeq ($(DEV_ARCH), osx)
  X_LIBS = -L/usr/OpenMotif/lib -L/usr/X11/lib -L/opt/X11/lib -lXm -lXmu -lXt -lX11
 endif
 
+ifeq ($(DEV_ARCH), solaris9)
+ X_LIBS = -lXm -lXmu -lXt -lX11
+endif
+
 # For nearly everyone else:
 # X_LIBS = -lXm -lXmu -lXt -lX11
 # For Sun's (at least running X/Motif as installed on our machines):
@@ -69,6 +77,11 @@ SYS_LIBS =
 # SYS_LIBS = -lresolv
 # For Dell SVR4:
 # SYS_LIBS = -lnsl -lsocket -lc -lucb
+
+ifeq ($(DEV_ARCH), solaris9)
+ SYS_LIBS = -lnsl -lsocket
+endif
+
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,9 @@
 # For normal machines with normal compilers:
 ifeq ($(DEV_ARCH), linux)
  CC = cc -I/usr/include/X11 -I/usr/include -Dlinux
-else
+endif
+
+ifeq ($(DEV_ARCH), osx)
  CC = cc -DNEXT -I/usr/include/X11 -I/opt/X11/include -I/usr/OpenMotif/include -mmacosx-version-min=10.5 -arch i386 -Dosx
 endif
 


### PR DESCRIPTION
Removing quotes around the arch strings seems to work.
